### PR TITLE
* [jsfm] move setup to a seperate file

### DIFF
--- a/html5/render/native/index.js
+++ b/html5/render/native/index.js
@@ -16,36 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { subversion } from '../../../package.json'
-import runtime from '../../runtime'
+import setup from './setup'
 import frameworks from '../../frameworks/index'
-import services from '../../services/index'
 
-const { init, config } = runtime
-config.frameworks = frameworks
-const { native, transformer } = subversion
-
-for (const serviceName in services) {
-  runtime.service.register(serviceName, services[serviceName])
-}
-
-runtime.freezePrototype()
-runtime.setNativeConsole()
-
-// register framework meta info
-global.frameworkVersion = native
-global.transformerVersion = transformer
-
-// init frameworks
-const globalMethods = init(config)
-
-// set global methods
-for (const methodName in globalMethods) {
-  global[methodName] = (...args) => {
-    const ret = globalMethods[methodName](...args)
-    if (ret instanceof Error) {
-      console.error(ret.toString())
-    }
-    return ret
-  }
-}
+setup(frameworks)

--- a/html5/render/native/setup.js
+++ b/html5/render/native/setup.js
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { subversion } from '../../../package.json'
+import runtime from '../../runtime'
+import services from '../../services/index'
+
+/**
+ * Setup frameworks with runtime.
+ * You can package more frameworks by
+ *  passing them as arguments.
+ */
+export default function (frameworks) {
+  const { init, config } = runtime
+  config.frameworks = frameworks
+  const { native, transformer } = subversion
+
+  for (const serviceName in services) {
+    runtime.service.register(serviceName, services[serviceName])
+  }
+
+  runtime.freezePrototype()
+  runtime.setNativeConsole()
+
+  // register framework meta info
+  global.frameworkVersion = native
+  global.transformerVersion = transformer
+
+  // init frameworks
+  const globalMethods = init(config)
+
+  // set global methods
+  for (const methodName in globalMethods) {
+    global[methodName] = (...args) => {
+      const ret = globalMethods[methodName](...args)
+      if (ret instanceof Error) {
+        console.error(ret.toString())
+      }
+      return ret
+    }
+  }
+}
+


### PR DESCRIPTION
Default weex project will setup frameworks under `../../frameworks/index`. In some custom case, you can use whatever you want by pass the frameworks as arguments to  this `setup` function.

<!--

Notes: Weex will move into Apache Software Foundation (ASF) on Feb 24 2017.

Our new GitHub repo is https://github.com/apache/incubator-weex

After Feb 24 2017, we only accept pull requests from https://github.com/apache/incubator-weex

Thank you for your support.

----

注意：Weex 将于 2017-02-24 迁移至 Apache 基金会

届时我们会使用新的 GitHub 仓库：https://github.com/apache/incubator-weex 并在那里继续接受大家的 pull request。

更多详情请关注：https://github.com/weexteam/article/issues/130

感谢理解和支持

-->

<!--

It's ***RECOMMENDED*** to submit typo fix, new demo and tiny bugfix to `dev` branch. New feature and other modifications can be submitted to "domain" branch including `ios`, `android`, `jsfm`, `html5`.
    
See [Branch Strategy](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management) for more detail.

----

（请在***提交***前删除这段描述）

错别字修改、新 demo、较小的 bugfix 都可以直接提到 `dev` 分支；新需求以及任何你不确定影响面的改动，请提交到对应“领域”的分支（`ios`、`android`、`jsfm`、`html5`）。

查看完整的[分支策略 (英文)](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management)。

-->
